### PR TITLE
feat: initial implementation of the Projects and Repo pages

### DIFF
--- a/app/[locale]/projects/[org]/[repo]/page.tsx
+++ b/app/[locale]/projects/[org]/[repo]/page.tsx
@@ -1,0 +1,24 @@
+import { ROUTES } from '@/constants/routes'
+import { createDefaultMetadata } from '@/lib/metadata'
+import RepositoryContainer from '@/containers/repository/repository-container'
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; org: string; repo: string }>
+}) {
+  const { locale, org, repo } = await params
+
+  const metadata = await createDefaultMetadata({
+    title: `${org}/${repo} - Repository Details`,
+    description: `View details and pull requests for ${org}/${repo} repository`,
+    locale,
+    path: `${ROUTES.projects}/${org}/${repo}`,
+  })
+
+  return metadata
+}
+
+export default function Page() {
+  return <RepositoryContainer />
+}

--- a/app/[locale]/projects/page.tsx
+++ b/app/[locale]/projects/page.tsx
@@ -1,0 +1,20 @@
+import { ROUTES } from '@/constants/routes'
+import { createDefaultMetadata } from '@/lib/metadata'
+import ProjectsContainer from '@/containers/projects/projects-container'
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params
+
+  const metadata = await createDefaultMetadata({
+    title: 'Logos Contribute - Projects',
+    description: 'Explore open source projects and their pull requests',
+    locale,
+    path: ROUTES.projects,
+  })
+
+  return metadata
+}
+
+export default function Page() {
+  return <ProjectsContainer />
+}

--- a/app/api/pull-requests/route.ts
+++ b/app/api/pull-requests/route.ts
@@ -1,0 +1,100 @@
+import {
+  getAuth,
+  ghFetch,
+  GITHUB_API_BASE,
+  fetchPullRequestContributors,
+  makeLimiter,
+  DEFAULT_CONCURRENCY,
+} from '@/lib/github'
+import { PullRequest } from '@/lib/github'
+
+export const dynamic = 'force-dynamic'
+
+// This function now fetches PRs using the REST API for simpler page/per_page handling
+// and then fetches contributors for each PR.
+async function fetchPullRequestsWithContributors(
+  owner: string,
+  repo: string,
+  auth: { token?: string | null },
+  page: number,
+  per_page: number
+): Promise<PullRequest[]> {
+  const prsUrl = `${GITHUB_API_BASE}/repos/${owner}/${repo}/pulls?state=closed&sort=updated&direction=desc&page=${page}&per_page=${per_page}`
+
+  const response = await ghFetch(prsUrl, auth)
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`GitHub API error ${response.status}: ${body}`)
+  }
+
+  const data = await response.json() // Array of PR objects from REST API
+
+  // Map basic PR data first
+  const basicPrs: Omit<PullRequest, 'contributors'>[] = data.map((pr: any) => ({
+    number: pr.number,
+    title: pr.title,
+    createdAt: pr.created_at,
+    mergedAt: pr.merged_at,
+    closedAt: pr.closed_at, // Added closedAt
+    url: pr.html_url,
+    author: {
+      login: pr.user.login,
+      __typename: 'User',
+    },
+    repository: {
+      nameWithOwner: pr.base.repo.full_name,
+      url: pr.base.repo.html_url,
+    },
+  }))
+
+  // Now, fetch contributors for each PR in the current page
+  const limiter = makeLimiter(DEFAULT_CONCURRENCY)
+  const prsWithContributors = await Promise.all(
+    basicPrs.map(async (pr) => {
+      const contributors = await limiter(() =>
+        fetchPullRequestContributors(owner, repo, pr.number, auth)
+      )
+      return { ...pr, contributors }
+    })
+  )
+
+  return prsWithContributors
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const owner = searchParams.get('owner')
+    const repo = searchParams.get('repo')
+    const page = Number(searchParams.get('page')) || 1
+    const per_page = Number(searchParams.get('per_page')) || 40 // Default to 40 as per frontend
+
+    if (!owner || !repo) {
+      return Response.json({ error: 'owner and repo parameters are required' }, { status: 400 })
+    }
+
+    const auth = getAuth()
+    const pullRequests = await fetchPullRequestsWithContributors(owner, repo, auth, page, per_page)
+
+    const responseHeaders = new Headers()
+    responseHeaders.set('Content-Type', 'application/json')
+    responseHeaders.set('Cache-Control', 'no-store, no-cache, must-revalidate')
+    responseHeaders.set('Pragma', 'no-cache')
+    responseHeaders.set('Expires', '0')
+
+    return new Response(
+      JSON.stringify({
+        repository: `${owner}/${repo}`,
+        count: pullRequests.length, // This will be count for the current page
+        pullRequests,
+      }),
+      {
+        status: 200,
+        headers: responseHeaders,
+      }
+    )
+  } catch (e: any) {
+    console.error('Error fetching pull requests:', e)
+    return Response.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}

--- a/app/api/repositories/route.ts
+++ b/app/api/repositories/route.ts
@@ -1,0 +1,41 @@
+import { GITHUB_API_BASE, GITHUB_PER_PAGE, paginate, getAuth } from '@/lib/github'
+
+interface Repository {
+  id: number
+  name: string
+  full_name: string
+  html_url: string
+  description: string | null
+  language: string | null
+  stargazers_count: number
+  forks_count: number
+  updated_at: string
+}
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const org = searchParams.get('org')
+
+    if (!org) {
+      return Response.json({ error: 'org parameter is required' }, { status: 400 })
+    }
+
+    const auth = getAuth()
+    const url = `${GITHUB_API_BASE}/orgs/${encodeURIComponent(org)}/repos?type=public&per_page=${GITHUB_PER_PAGE}&sort=updated`
+    const repos = await paginate<Repository>(url, auth)
+    // Sort by stars (stargazers_count) in descending order
+    const sortedByStars = [...repos].sort((a, b) => b.stargazers_count - a.stargazers_count)
+
+    return Response.json({
+      organization: org,
+      count: sortedByStars.length,
+      repositories: sortedByStars,
+    })
+  } catch (e: any) {
+    console.error('Error fetching repositories:', e)
+    return Response.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}

--- a/components/site-headaer.tsx
+++ b/components/site-headaer.tsx
@@ -28,6 +28,14 @@ const Header = () => {
                 {t('nav.directory')}
               </Typography>
             </Link>
+            <Link href={ROUTES.projects}>
+              <Typography
+                variant="body1"
+                className={`underline-offset-5 hover:underline ${pathname === ROUTES.projects ? 'underline' : ''}`}
+              >
+                {t('nav.projects')}
+              </Typography>
+            </Link>
             <Link href={ROUTES.resources}>
               <Typography
                 variant="body1"

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -2,4 +2,5 @@ export const ROUTES = {
   home: '/',
   contributors: '/contributors',
   resources: '/resources',
+  projects: '/projects',
 }

--- a/containers/home/home-container.tsx
+++ b/containers/home/home-container.tsx
@@ -80,41 +80,37 @@ export default function HomeContainer() {
 
   return (
     <div className="min-h-screen">
-      <div className="mx-auto max-w-7xl px-4 py-20 sm:px-6 xl:px-0">
-        <div className="mb-12 flex flex-col gap-3 text-center">
-          <Typography variant="h1" className="mb-4 !text-3xl lg:!text-4xl">
-            {t('title')}
-          </Typography>
-          <Typography variant="subtitle1" className="mb-6 text-base sm:text-lg">
-            {t('subtitle')}
-          </Typography>
-        </div>
+      <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-20 text-center sm:px-6 xl:px-0">
+        <Typography variant="h1" className="mb-12 !text-3xl lg:!text-4xl">
+          {t('title')}
+        </Typography>
+        <Typography variant="subtitle1" className="mb-6 text-base sm:text-lg">
+          {t('subtitle')}
+        </Typography>
 
-        <div className="mb-12">
-          <div className="mx-auto max-w-md">
-            <div className="relative">
-              <input
-                type="text"
-                placeholder={t('search.placeholder')}
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="border-primary w-full border px-3 py-2 pl-10 text-sm sm:text-base"
-              />
-              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                <svg
-                  className="h-4 w-4 text-gray-400 sm:h-5 sm:w-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                  />
-                </svg>
-              </div>
+        <div className="mx-auto mb-12 max-w-md">
+          <div className="relative">
+            <input
+              type="text"
+              placeholder={t('search.placeholder')}
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="border-primary w-full border px-3 py-2 pl-10 text-sm sm:text-base"
+            />
+            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+              <svg
+                className="h-4 w-4 text-gray-400 sm:h-5 sm:w-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
+              </svg>
             </div>
           </div>
         </div>
@@ -147,138 +143,136 @@ export default function HomeContainer() {
         </div>
 
         <div className="border-primary border">
-          <div className="border-primary border-b px-4 py-4 sm:px-6">
-            <Typography variant="h3" className="!text-lg sm:!text-xl">
-              {t('contributors.title')}
-            </Typography>
-          </div>
+          <Typography
+            variant="h3"
+            className="border-primary border-b px-4 py-4 !text-lg sm:px-6 sm:!text-xl"
+          >
+            {t('contributors.title')}
+          </Typography>
           <div className="divide-primary divide-y">
             {currentContributors.length > 0 ? (
               currentContributors.map((contributor) => (
-                <div key={contributor.id} className="p-4 sm:p-6">
-                  <div className="flex flex-col space-y-3 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-4">
-                    <img
-                      src={contributor.avatarUrl}
-                      alt={`${contributor.username} avatar`}
-                      className="h-10 w-10 rounded-full sm:h-12 sm:w-12"
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-col space-y-1 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-3">
-                        <a
-                          href={contributor.profileUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-base font-medium hover:underline sm:text-lg"
-                        >
-                          {contributor.username}
-                        </a>
-                        <span className="inline-flex items-center text-xs font-medium">
-                          {contributor.contributions} {t('contributors.contributions')}
-                        </span>
-                      </div>
-                      <div className="mt-1 text-xs sm:text-sm">
-                        {t('contributors.latest')}: {contributor.latestRepo} •{' '}
-                        {formatDate(contributor.latestContribution)}
-                      </div>
-                    </div>
-                    <div className="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2">
-                      <a href={contributor.profileUrl} target="_blank" rel="noopener noreferrer">
-                        <Button variant="outlined" size="small" className="w-full sm:w-auto">
-                          {t('contributors.viewGithubProfile')}
-                        </Button>
+                <div
+                  key={contributor.id}
+                  className="flex flex-col space-y-3 p-4 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-4 sm:p-6"
+                >
+                  <img
+                    src={contributor.avatarUrl}
+                    alt={`${contributor.username} avatar`}
+                    className="h-10 w-10 rounded-full sm:h-12 sm:w-12"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-col space-y-1 sm:flex-row sm:items-center sm:space-y-0 sm:space-x-3">
+                      <a
+                        href={contributor.profileUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-base font-medium hover:underline sm:text-lg"
+                      >
+                        {contributor.username}
                       </a>
-                      <Link href={`${ROUTES.contributors}/${contributor.username}`}>
-                        <Button size="small" className="w-full sm:w-auto">
-                          {t('contributors.viewDetails')}
-                        </Button>
-                      </Link>
+                      <span className="inline-flex items-center text-xs font-medium">
+                        {contributor.contributions} {t('contributors.contributions')}
+                      </span>
                     </div>
+                    <div className="mt-1 text-xs sm:text-sm">
+                      {t('contributors.latest')}: {contributor.latestRepo} •{' '}
+                      {formatDate(contributor.latestContribution)}
+                    </div>
+                  </div>
+                  <div className="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2">
+                    <a href={contributor.profileUrl} target="_blank" rel="noopener noreferrer">
+                      <Button variant="outlined" size="small" className="w-full sm:w-auto">
+                        {t('contributors.viewGithubProfile')}
+                      </Button>
+                    </a>
+                    <Link href={`${ROUTES.contributors}/${contributor.username}`}>
+                      <Button size="small" className="w-full sm:w-auto">
+                        {t('contributors.viewDetails')}
+                      </Button>
+                    </Link>
                   </div>
                 </div>
               ))
             ) : (
-              <div className="p-4 text-center sm:p-6">
-                <Typography variant="body2">{t('contributors.noResults')}</Typography>
-              </div>
+              <Typography variant="body2" className="p-4 text-center sm:p-6">
+                {t('contributors.noResults')}
+              </Typography>
             )}
           </div>
 
           {totalPages > 1 && (
-            <div className="border-primary border-t px-4 py-4 sm:px-6">
-              <div className="flex flex-col items-center gap-3 space-y-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
-                <Typography variant="body2" className="text-center sm:text-left">
-                  {t('contributors.pagination.showing', {
-                    start: startIndex + 1,
-                    end: Math.min(endIndex, filteredContributors.length),
-                    total: filteredContributors.length,
-                  })}
-                </Typography>
-                <div className="flex flex-row space-y-2 space-x-2 sm:space-y-0">
-                  <Button
-                    variant="outlined"
-                    disabled={currentPage === 1}
-                    onClick={() => handlePageChange(currentPage - 1)}
-                    className="!h-10"
-                  >
-                    {t('contributors.pagination.previous')}
-                  </Button>
-                  <div className="flex justify-center space-x-1">
-                    {Array.from({ length: totalPages }, (_, index) => {
-                      const page = index + 1
-                      const isCurrentPage = page === currentPage
-                      const isNearCurrent = Math.abs(page - currentPage) <= 2
-                      const isFirstOrLast = page === 1 || page === totalPages
+            <div className="border-primary flex flex-col items-center gap-3 space-y-4 border-t px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0 sm:px-6">
+              <Typography variant="body2" className="text-center sm:text-left">
+                {t('contributors.pagination.showing', {
+                  start: startIndex + 1,
+                  end: Math.min(endIndex, filteredContributors.length),
+                  total: filteredContributors.length,
+                })}
+              </Typography>
+              <div className="flex flex-row space-y-2 space-x-2 sm:space-y-0">
+                <Button
+                  variant="outlined"
+                  disabled={currentPage === 1}
+                  onClick={() => handlePageChange(currentPage - 1)}
+                  className="!h-10"
+                >
+                  {t('contributors.pagination.previous')}
+                </Button>
+                <div className="flex justify-center space-x-1">
+                  {Array.from({ length: totalPages }, (_, index) => {
+                    const page = index + 1
+                    const isCurrentPage = page === currentPage
+                    const isNearCurrent = Math.abs(page - currentPage) <= 2
+                    const isFirstOrLast = page === 1 || page === totalPages
 
-                      if (isFirstOrLast || isNearCurrent) {
-                        return (
-                          <Button
-                            key={page}
-                            variant={isCurrentPage ? 'filled' : 'outlined'}
-                            onClick={() => handlePageChange(page)}
-                            className="!h-10 !w-10 !p-0"
-                          >
-                            {page}
-                          </Button>
-                        )
-                      } else if (page === currentPage - 3 || page === currentPage + 3) {
-                        return (
-                          <span key={page} className="px-2 py-2">
-                            ...
-                          </span>
-                        )
-                      }
-                      return null
-                    })}
-                  </div>
-                  <Button
-                    variant="outlined"
-                    disabled={currentPage === totalPages}
-                    onClick={() => handlePageChange(currentPage + 1)}
-                    className="!h-10"
-                  >
-                    {t('contributors.pagination.next')}
-                  </Button>
+                    if (isFirstOrLast || isNearCurrent) {
+                      return (
+                        <Button
+                          key={page}
+                          variant={isCurrentPage ? 'filled' : 'outlined'}
+                          onClick={() => handlePageChange(page)}
+                          className="!h-10 !w-10 !p-0"
+                        >
+                          {page}
+                        </Button>
+                      )
+                    } else if (page === currentPage - 3 || page === currentPage + 3) {
+                      return (
+                        <span key={page} className="px-2 py-2">
+                          ...
+                        </span>
+                      )
+                    }
+                    return null
+                  })}
                 </div>
+                <Button
+                  variant="outlined"
+                  disabled={currentPage === totalPages}
+                  onClick={() => handlePageChange(currentPage + 1)}
+                  className="!h-10"
+                >
+                  {t('contributors.pagination.next')}
+                </Button>
               </div>
             </div>
           )}
         </div>
 
-        <div className="mt-8 text-center sm:mt-12">
-          <div className="border-primary flex flex-col gap-4 border p-4 sm:p-8">
-            <Typography variant="h3" className="mb-4 text-lg sm:text-xl">
-              {t('cta.title')}
-            </Typography>
-            <Typography variant="body1" className="mb-6 text-sm sm:text-base">
-              {t('cta.description')}
-            </Typography>
-            <div className="flex justify-center">
-              <Link href={ROUTES.resources}>
-                <Button variant="outlined" size="small" className="w-full sm:w-auto">
-                  {t('cta.viewGuidelines')}
-                </Button>
-              </Link>
-            </div>
+        <div className="border-primary mt-8 flex flex-col gap-4 border p-4 text-center sm:mt-12 sm:p-8">
+          <Typography variant="h3" className="mb-4 text-lg sm:text-xl">
+            {t('cta.title')}
+          </Typography>
+          <Typography variant="body1" className="mb-6 text-sm sm:text-base">
+            {t('cta.description')}
+          </Typography>
+          <div className="flex justify-center">
+            <Link href={ROUTES.resources}>
+              <Button variant="outlined" size="small" className="w-full sm:w-auto">
+                {t('cta.viewGuidelines')}
+              </Button>
+            </Link>
           </div>
         </div>
       </div>

--- a/containers/projects/projects-container.tsx
+++ b/containers/projects/projects-container.tsx
@@ -1,0 +1,157 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useTranslations } from 'next-intl'
+import { Button, Typography, Tabs, TabItem } from '@acid-info/lsd-react'
+import { useRouter } from 'next/navigation'
+import { ROUTES } from '@/constants/routes'
+import { ORGS } from '@/constants/orgs'
+import { useProjectsData } from '@/hooks/useProjectsData'
+
+export default function ProjectsContainer() {
+  const t = useTranslations('projects')
+  const router = useRouter()
+  const [activeOrg, setActiveOrg] = useState<string>(ORGS[0])
+  const [currentPage, setCurrentPage] = useState(1)
+  const itemsPerPage = 9
+
+  const { repositories, loading } = useProjectsData(activeOrg)
+
+  const totalPages = Math.ceil(repositories.length / itemsPerPage)
+  const startIndex = (currentPage - 1) * itemsPerPage
+  const endIndex = startIndex + itemsPerPage
+  const currentRepositories = repositories.slice(startIndex, endIndex)
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page)
+  }
+
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [activeOrg])
+
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-20 text-center sm:px-6 xl:px-0">
+        <Typography variant="h1" className="mb-12 !text-3xl lg:!text-4xl">
+          {t('title')}
+        </Typography>
+        <Typography variant="subtitle1" className="mb-6 text-base sm:text-lg">
+          {t('subtitle')}
+        </Typography>
+
+        <div className="mx-auto max-w-4xl">
+          <Tabs activeTab={activeOrg} onChange={(value) => setActiveOrg(value)}>
+            {ORGS.map((org) => (
+              <TabItem key={org} name={org} value={org}>
+                {org}
+              </TabItem>
+            ))}
+          </Tabs>
+        </div>
+
+        <div className="border-primary border">
+          <Typography
+            variant="h3"
+            className="border-primary border-b px-4 py-4 !text-lg sm:px-6 sm:!text-xl"
+          >
+            {activeOrg} Projects
+          </Typography>
+          <div className="p-4 sm:p-6">
+            {loading ? (
+              <Typography variant="body2" className="p-8 text-center">
+                {t('loading')}
+              </Typography>
+            ) : repositories.length > 0 ? (
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {currentRepositories.map((repo) => (
+                  <Button
+                    key={repo.id}
+                    variant="outlined"
+                    className="h-auto p-4 text-left"
+                    onClick={() => router.push(`${ROUTES.projects}/${activeOrg}/${repo.name}`)}
+                  >
+                    <div className="flex flex-col space-y-2">
+                      <Typography variant="h4" className="!text-base font-medium">
+                        {repo.name}
+                      </Typography>
+                      {repo.description && (
+                        <Typography variant="body2" className="line-clamp-2 text-sm text-gray-600">
+                          {repo.description}
+                        </Typography>
+                      )}
+                      <div className="flex items-center space-x-4 text-xs text-gray-500">
+                        {repo.language && <span>{repo.language}</span>}
+                        <span>⭐ {repo.stargazers_count}</span>
+                        <span>🍴 {repo.forks_count}</span>
+                      </div>
+                    </div>
+                  </Button>
+                ))}
+              </div>
+            ) : (
+              <Typography variant="body2" className="p-4 text-center sm:p-6">
+                No repositories found for {activeOrg}.
+              </Typography>
+            )}
+
+            {totalPages > 1 && (
+              <div className="flex flex-col items-center gap-3 space-y-4 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0 sm:px-6">
+                <Typography variant="body2" className="text-center sm:text-left">
+                  Showing {startIndex + 1}-{Math.min(endIndex, repositories.length)} of{' '}
+                  {repositories.length} repositories
+                </Typography>
+                <div className="flex flex-row space-y-2 space-x-2 sm:space-y-0">
+                  <Button
+                    variant="outlined"
+                    disabled={currentPage === 1}
+                    onClick={() => handlePageChange(currentPage - 1)}
+                    className="!h-10"
+                  >
+                    Previous
+                  </Button>
+                  <div className="flex justify-center space-x-1">
+                    {Array.from({ length: totalPages }, (_, index) => {
+                      const page = index + 1
+                      const isCurrentPage = page === currentPage
+                      const isNearCurrent = Math.abs(page - currentPage) <= 2
+                      const isFirstOrLast = page === 1 || page === totalPages
+
+                      if (isFirstOrLast || isNearCurrent) {
+                        return (
+                          <Button
+                            key={page}
+                            variant={isCurrentPage ? 'filled' : 'outlined'}
+                            onClick={() => handlePageChange(page)}
+                            className="!h-10 !w-10 !p-0"
+                          >
+                            {page}
+                          </Button>
+                        )
+                      } else if (page === currentPage - 3 || page === currentPage + 3) {
+                        return (
+                          <span key={page} className="px-2 py-2">
+                            ...
+                          </span>
+                        )
+                      }
+                      return null
+                    })}
+                  </div>
+                  <Button
+                    variant="outlined"
+                    disabled={currentPage === totalPages}
+                    onClick={() => handlePageChange(currentPage + 1)}
+                    className="!h-10"
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/containers/repository/repository-container.tsx
+++ b/containers/repository/repository-container.tsx
@@ -1,0 +1,267 @@
+'use client'
+
+import React, { useRef } from 'react'
+import { useTranslations } from 'next-intl'
+import { Button, Typography } from '@acid-info/lsd-react'
+import { Link } from '@/i18n/navigation'
+import { ROUTES } from '@/constants/routes'
+import { useParams } from 'next/navigation'
+import { useRepositoryData } from '@/hooks/useRepositoryData'
+
+export default function RepositoryContainer() {
+  const t = useTranslations('repository')
+  const params = useParams()
+  const { org, repo } = params as { org: string; repo: string }
+  const timelineContainerRef = useRef<HTMLDivElement>(null)
+
+  const {
+    loading,
+    notFound,
+    prsLoading,
+    prsError,
+    pullRequests,
+    repoData,
+    repoDataLoading,
+    repoDataError,
+    totalPullRequests,
+    formatDate,
+  } = useRepositoryData(org, repo)
+
+  if (loading || repoDataLoading) {
+    return (
+      <Typography variant="body2" className="flex min-h-screen items-center justify-center">
+        {t('loading')}
+      </Typography>
+    )
+  }
+
+  if (notFound) {
+    return null // Redirecting is handled by the hook
+  }
+
+  if (repoDataError && !repoData) {
+    return (
+      <Typography
+        variant="body2"
+        className="flex min-h-screen items-center justify-center text-red-500"
+      >
+        Error loading repository data: {repoDataError}
+      </Typography>
+    )
+  }
+
+  return (
+    <div className="min-h-screen">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 xl:px-0">
+        <div className="mb-8">
+          <Link href={ROUTES.projects}>
+            <Button variant="outlined">{t('backToProjects')}</Button>
+          </Link>
+        </div>
+        {repoData && (
+          <div className="mb-8 grid gap-8 lg:grid-cols-3">
+            <div className="lg:col-span-2">
+              <div className="border-primary border p-8">
+                <div className="mb-6">
+                  <Typography variant="h1" className="mb-2">
+                    {repoData.full_name}
+                  </Typography>
+                  {repoData.description && (
+                    <Typography variant="body1" className="text-gray-600">
+                      {repoData.description}
+                    </Typography>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+                  <div className="border-primary border p-6 text-center">
+                    <Typography variant="h2" className="mb-2">
+                      {totalPullRequests}
+                    </Typography>
+                    <Typography variant="body2">Merged Pull Requests</Typography>
+                  </div>
+                  <div className="border-primary border p-6 text-center">
+                    <Typography variant="h2" className="mb-2">
+                      {repoData.stargazers_count}
+                    </Typography>
+                    <Typography variant="body2">Stars</Typography>
+                  </div>
+                  <div className="border-primary border p-6 text-center">
+                    <Typography variant="h2" className="mb-2">
+                      {repoData.forks_count}
+                    </Typography>
+                    <Typography variant="body2">Forks</Typography>
+                  </div>
+                </div>
+
+                <div className="mt-8">
+                  <a href={repoData.html_url} target="_blank" rel="noopener noreferrer">
+                    <Button variant="outlined">View on GitHub</Button>
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            <div className="lg:col-span-1">
+              <div className="border-primary border p-6">
+                <Typography variant="h3" className="mb-4">
+                  Quick Stats
+                </Typography>
+                <div className="space-y-4">
+                  <div className="flex justify-between">
+                    <Typography variant="body2">Language</Typography>
+                    <Typography variant="body2" className="font-medium">
+                      {repoData.language || 'N/A'}
+                    </Typography>
+                  </div>
+                  <div className="flex justify-between">
+                    <Typography variant="body2">Open Issues</Typography>
+                    <Typography variant="body2" className="font-medium">
+                      {repoData.open_issues_count}
+                    </Typography>
+                  </div>
+                  <div className="flex justify-between">
+                    <Typography variant="body2">Last Updated</Typography>
+                    <Typography variant="body2" className="font-medium">
+                      {formatDate(repoData.updated_at)}
+                    </Typography>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+        {/* Main Content Area for Timeline */}
+        <div className="border-primary border">
+          <div className="border-primary border-b px-8 py-6">
+            <Typography variant="h2">{t('pullRequestTimeline')}</Typography>
+          </div>
+          <div ref={timelineContainerRef} className="overflow-x-auto py-8">
+            {' '}
+            {/* Added padding for the timeline content */}
+            {prsError && (
+              <Typography variant="body2" className="text-center text-red-500">
+                {t('errorLoadingPullRequests', { error: prsError })}
+              </Typography>
+            )}
+            {prsLoading && (
+              <Typography variant="body2" className="flex justify-center py-10">
+                {' '}
+                {/* Added py-10 for better spacing */}
+                {t('loadingPullRequests')}
+              </Typography>
+            )}
+            {!prsLoading && !prsError && pullRequests.length > 0 && (
+              <div className="w-fit px-8">
+                <div>
+                  <div
+                    className="grid auto-cols-max grid-flow-col"
+                    style={{
+                      gridTemplateRows: 'auto 3rem 1fr 3rem auto', // Added padding rows
+                      gridAutoFlow: 'column',
+                    }}
+                  >
+                    {pullRequests.map((pr, index) => {
+                      const isEven = index % 2 === 0
+                      // Use pr.url for the key, as it provides a globally unique identifier for each pull request.
+                      // This directly addresses the "Encountered two children with the same key" error.
+                      const itemKey = `pr-item-${pr.url}`
+
+                      return (
+                        // Use a wrapper div to group the three parts of a single PR item.
+                        // This wrapper gets the unique key.
+                        <div key={itemKey} style={{ display: 'contents' }}>
+                          {/* Card */}
+                          <div
+                            className="flex w-64"
+                            style={{
+                              gridRowStart: isEven ? '1' : '5',
+                              gridColumnStart: index * 2 + 1,
+                              alignItems: isEven ? 'self-end' : 'self-start',
+                            }}
+                          >
+                            <a
+                              href={pr.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="border-primary bg-background block rounded-lg border p-4 shadow-sm transition-shadow hover:shadow-md"
+                            >
+                              <Typography
+                                variant="body1" // Changed from h3 to body1 for smaller text
+                                className="!text-sm leading-tight font-semibold" // Adjusted text size
+                              >
+                                #{pr.number} {pr.title}
+                              </Typography>
+                              {/* Contributors Avatars */}
+                              {pr.contributors && pr.contributors.length > 0 && (
+                                <div className="mt-3 flex items-center">
+                                  <div className="flex -space-x-2">
+                                    {pr.contributors.slice(0, 10).map((contributor) => (
+                                      <img
+                                        key={contributor.login}
+                                        src={contributor.avatar_url}
+                                        alt={contributor.login}
+                                        title={`${contributor.login} (${contributor.commitCount} commits)`}
+                                        className="border-background h-8 w-8 rounded-full border-2" // Increased avatar size
+                                      />
+                                    ))}
+                                  </div>
+                                  {pr.contributors.length > 10 && (
+                                    <Typography variant="body2" className="ml-2 text-xs">
+                                      +{pr.contributors.length - 10}
+                                    </Typography>
+                                  )}
+                                </div>
+                              )}
+                            </a>
+                          </div>
+                          {/* Date */}
+                          <div
+                            className="flex justify-self-center py-1 text-sm"
+                            style={{
+                              gridRowStart: isEven ? '2' : '4',
+                              gridColumnStart: index * 2 + 1,
+                              alignItems: isEven ? 'self-end' : 'self-start',
+                            }}
+                          >
+                            <Typography
+                              variant="body2"
+                              className="text-gray-600 dark:text-gray-400"
+                            >
+                              {formatDate(pr.mergedAt || pr.createdAt)}
+                            </Typography>
+                          </div>
+                          {/* Dot */}
+                          <div
+                            className="relative flex items-center justify-center self-center"
+                            style={{
+                              gridRowStart: '3',
+                              gridColumnStart: index * 2 + 1,
+                            }}
+                          >
+                            <div
+                              className="absolute top-1/2 right-0 left-0 z-0 h-0.5 bg-gray-300 dark:bg-gray-700"
+                              style={{ transform: 'translateY(-50%)' }}
+                            ></div>
+                            <div className="border-primary bg-background z-10 h-6 w-6 rounded-full border-4"></div>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              </div>
+            )}
+            {!prsLoading && !prsError && pullRequests.length === 0 && (
+              <Typography variant="body2" className="text-center">
+                {t('noPullRequests')}
+              </Typography>
+            )}
+          </div>{' '}
+          {/* End of p-8 padding div */}
+        </div>{' '}
+        {/* End of border-primary border div for timeline */}
+      </div>
+    </div>
+  )
+}

--- a/hooks/useProjectsData.ts
+++ b/hooks/useProjectsData.ts
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { ORGS } from '@/constants/orgs'
+
+interface Repository {
+  id: number
+  name: string
+  full_name: string
+  html_url: string
+  description: string | null
+  language: string | null
+  stargazers_count: number
+  forks_count: number
+  updated_at: string
+}
+
+export const useProjectsData = (activeOrg: string) => {
+  const [repositories, setRepositories] = useState<Repository[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    const fetchRepositories = async () => {
+      setLoading(true)
+      try {
+        const apiUrl = new URL(`${window.location.origin}/api/repositories`)
+        apiUrl.searchParams.append('org', activeOrg)
+
+        const response = await fetch(apiUrl.toString())
+        if (!response.ok) {
+          throw new Error(`Failed to fetch repositories: ${response.statusText}`)
+        }
+        const data = await response.json()
+        setRepositories(data.repositories || [])
+      } catch (error: any) {
+        console.error('Error fetching repositories:', error)
+        setRepositories([])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchRepositories()
+  }, [activeOrg])
+
+  return {
+    repositories,
+    loading,
+  }
+}

--- a/hooks/useRepositoryData.ts
+++ b/hooks/useRepositoryData.ts
@@ -1,0 +1,148 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { PullRequest } from '@/lib/github'
+
+interface RepositoryData {
+  name: string
+  full_name: string
+  description: string | null
+  stargazers_count: number
+  forks_count: number
+  open_issues_count: number
+  language: string | null
+  updated_at: string
+  html_url: string
+}
+
+export const useRepositoryData = (org: string, repo: string) => {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [prsLoading, setPrsLoading] = useState(false)
+  const [prsError, setPrsError] = useState<string | null>(null)
+  const [pullRequests, setPullRequests] = useState<PullRequest[]>([])
+  const [repoData, setRepoData] = useState<RepositoryData | null>(null)
+  const [repoDataLoading, setRepoDataLoading] = useState(true)
+  const [repoDataError, setRepoDataError] = useState<string | null>(null)
+  const [totalPullRequests, setTotalPullRequests] = useState<number>(0)
+
+  useEffect(() => {
+    const fetchTotalPullRequestsCount = async () => {
+      try {
+        const response = await fetch(
+          `https://api.github.com/search/issues?q=repo:${org}/${repo}+is:pr+is:merged&per_page=1`
+        )
+        if (!response.ok) {
+          // Non-critical error, don't block the whole UI
+          console.error(`Failed to fetch total PR count: ${response.statusText}`)
+          return
+        }
+        const data = await response.json()
+        setTotalPullRequests(data.total_count || 0)
+      } catch (error: any) {
+        console.error('Error fetching total PR count:', error)
+      }
+    }
+
+    const fetchRepositoryData = async () => {
+      if (!org || !repo) return
+
+      setRepoDataLoading(true)
+      setRepoDataError(null)
+      try {
+        const response = await fetch(`https://api.github.com/repos/${org}/${repo}`)
+        if (!response.ok) {
+          if (response.status === 404) {
+            setNotFound(true)
+          }
+          throw new Error(`Failed to fetch repository: ${response.statusText}`)
+        }
+        const data: RepositoryData = await response.json()
+        setRepoData(data)
+        fetchTotalPullRequestsCount() // Fetch PR count after repo data is successfully fetched
+      } catch (error: any) {
+        console.error('Error fetching repository data:', error)
+        setRepoDataError(error.message || 'Failed to load repository details')
+        if (error.message.includes('404')) {
+          setNotFound(true)
+        }
+      } finally {
+        setRepoDataLoading(false)
+        setLoading(false)
+      }
+    }
+
+    fetchRepositoryData()
+  }, [org, repo])
+
+  const fetchPullRequestsData = async () => {
+    if (!org || !repo || prsLoading) return
+
+    setPrsLoading(true)
+    setPullRequests([])
+    setPrsError(null)
+
+    try {
+      const apiUrl = new URL(`${window.location.origin}/api/pull-requests`)
+      apiUrl.searchParams.append('owner', org)
+      apiUrl.searchParams.append('repo', repo)
+      apiUrl.searchParams.append('page', '1')
+      apiUrl.searchParams.append('per_page', '1000')
+
+      const response = await fetch(apiUrl.toString())
+      if (!response.ok) {
+        throw new Error(`Failed to fetch pull requests: ${response.statusText}`)
+      }
+      const data = await response.json()
+      let incomingPrs = data.pullRequests || []
+
+      incomingPrs.sort((a: PullRequest, b: PullRequest) => {
+        const dateA = new Date(a.mergedAt || a.closedAt || a.createdAt).getTime()
+        const dateB = new Date(b.mergedAt || b.closedAt || b.createdAt).getTime()
+        return dateB - dateA
+      })
+
+      setPullRequests(incomingPrs)
+    } catch (error: any) {
+      console.error('Error fetching pull requests:', error)
+      setPrsError(error.message || 'An unknown error occurred')
+    } finally {
+      setPrsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (repoData && org && repo && pullRequests.length === 0 && !prsLoading) {
+      fetchPullRequestsData()
+    }
+  }, [repoData, org, repo])
+
+  useEffect(() => {
+    if (notFound) {
+      router.push('/projects') // TODO: Replace with ROUTES.projects if available in hook context or pass it
+    }
+  }, [notFound, router])
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  }
+
+  return {
+    loading,
+    notFound,
+    prsLoading,
+    prsError,
+    pullRequests,
+    repoData,
+    repoDataLoading,
+    repoDataError,
+    totalPullRequests,
+    formatDate,
+  }
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -172,18 +172,16 @@ export const clampWindow = (since?: string | null, until?: string | null) => {
   return { since: iso(since) || w.since, until: iso(until) || w.until }
 }
 
-export const prQuery = `
-query RepoPRs($owner:String!,$name:String!,$after:String){
-  repository(owner:$owner,name:$name){
-    nameWithOwner url
-    pullRequests(states:[OPEN,MERGED,CLOSED], first:100, orderBy:{field:CREATED_AT,direction:DESC}, after:$after){
-      nodes{ number createdAt url author{ login __typename }
-        repository{ nameWithOwner url }
-      }
-      pageInfo{ hasNextPage endCursor }
-    }
-  }
-}`
+import {
+  Commit,
+  PullRequestContributor,
+  PullRequest,
+  PullRequestsResponse,
+  prQuery,
+} from './github/types'
+
+export type { Commit, PullRequestContributor, PullRequest, PullRequestsResponse }
+export { prQuery }
 
 export function parsePrUrl(url: string): { owner: string; repo: string; number: string } | null {
   const m = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/)
@@ -193,4 +191,84 @@ export function parsePrUrl(url: string): { owner: string; repo: string; number: 
 export function parseCommitUrlToRepo(url: string): string | null {
   const m = url.match(/github\.com\/([^/]+)\/([^/]+)\/commit\//)
   return m ? `${m[1]}/${m[2]}` : null
+}
+
+export async function fetchPullRequestContributors(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  auth: GitHubAuth = getAuth()
+): Promise<PullRequestContributor[]> {
+  const commitsUrl = `${GITHUB_API_BASE}/repos/${owner}/${repo}/pulls/${prNumber}/commits?per_page=100`
+  const commits: Commit[] = await paginate<Commit>(commitsUrl, auth)
+
+  const contributorMap = new Map<string, PullRequestContributor>()
+
+  for (const commit of commits) {
+    if (commit.author?.login) {
+      const login = commit.author.login
+      const avatar_url = commit.author.avatar_url
+      if (contributorMap.has(login)) {
+        const contributor = contributorMap.get(login)!
+        contributor.commitCount++
+      } else {
+        contributorMap.set(login, { login, avatar_url, commitCount: 1 })
+      }
+    }
+  }
+
+  return Array.from(contributorMap.values()).sort((a, b) => b.commitCount - a.commitCount)
+}
+
+export async function fetchPullRequests(
+  owner: string,
+  repo: string,
+  auth: GitHubAuth = getAuth(),
+  limit = DEFAULT_PAGINATE_LIMIT
+): Promise<PullRequest[]> {
+  let basicPullRequests: Omit<PullRequest, 'contributors'>[] = [] // Use Omit to type basic PRs
+  let hasNextPage = true
+  let after: string | null = null
+
+  // Step 1: Fetch all basic PR data first (up to the limit) to ensure correct order.
+  // The GraphQL query already sorts them by UPDATED_AT DESC.
+  while (hasNextPage && basicPullRequests.length < limit) {
+    const variables = {
+      owner,
+      name: repo,
+      after,
+    }
+
+    const data = await graphql<PullRequestsResponse>(prQuery, variables, auth)
+
+    basicPullRequests = basicPullRequests.concat(data.repository.pullRequests.nodes)
+
+    hasNextPage = data.repository.pullRequests.pageInfo.hasNextPage
+    after = data.repository.pullRequests.pageInfo.endCursor
+  }
+
+  // Slice to ensure we don't exceed the limit, as the last fetch might go over.
+  const finalPrList = basicPullRequests.slice(0, limit)
+
+  // Step 2: Now, fetch contributors for each PR in the correctly sorted list.
+  const limiter = makeLimiter(DEFAULT_CONCURRENCY) // Use existing concurrency limit
+  const prsWithContributors = await Promise.all(
+    finalPrList.map(async (pr) => {
+      const contributors = await limiter(() =>
+        fetchPullRequestContributors(owner, repo, pr.number, auth)
+      )
+      // Combine the basic PR data with the fetched contributors
+      return { ...pr, contributors }
+    })
+  )
+
+  // Step 3: Final sort by mergedAt date to ensure strict chronological order.
+  // PRs without a mergedAt date (e.g., not actually merged) will be sorted by createdAt.
+  prsWithContributors.sort((a, b) => {
+    const dateA = new Date(a.mergedAt || a.createdAt).getTime()
+    const dateB = new Date(b.mergedAt || b.createdAt).getTime()
+    return dateB - dateA // Sorts in descending order (newest first)
+  })
+
+  return prsWithContributors
 }

--- a/lib/github/types.ts
+++ b/lib/github/types.ts
@@ -1,0 +1,59 @@
+export interface Commit {
+  sha: string
+  url: string
+  author: {
+    login: string
+    avatar_url: string
+  } | null // Author can be null if the commit author is not a GitHub user
+}
+
+export interface PullRequestContributor {
+  login: string
+  avatar_url: string
+  commitCount: number
+}
+
+export interface PullRequest {
+  number: number
+  title: string
+  createdAt: string
+  mergedAt: string | null
+  closedAt: string | null // Added closedAt
+  url: string
+  author: {
+    login: string
+    __typename: string
+  }
+  repository: {
+    nameWithOwner: string
+    url: string
+  }
+  contributors: PullRequestContributor[]
+}
+
+export interface PullRequestsResponse {
+  repository: {
+    nameWithOwner: string
+    url: string
+    pullRequests: {
+      nodes: PullRequest[]
+      pageInfo: {
+        hasNextPage: boolean
+        endCursor: string
+      }
+    }
+  }
+}
+
+export const prQuery = `
+query RepoPRs($owner:String!,$name:String!,$after:String){
+  repository(owner:$owner,name:$name){
+    nameWithOwner url
+    pullRequests(states:[MERGED], first:100, orderBy:{field:UPDATED_AT,direction:DESC}, after:$after){
+      nodes{ number title createdAt mergedAt url author{ login __typename }
+        repository{ nameWithOwner url }
+      }
+      pageInfo{ hasNextPage endCursor }
+    }
+  }
+}`

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,7 +5,8 @@
       "directory": "Directory",
       "resources": "Resources",
       "contributors": "Contributors",
-      "miilestones": "Milestones"
+      "miilestones": "Milestones",
+      "projects": "Projects"
     }
   },
   "home": {
@@ -55,5 +56,40 @@
     "contribution": "Contribution",
     "view": "View"
   },
-  "footer": {}
+  "repository": {
+    "backToProjects": "Back to Projects",
+    "placeholderContent": "Repository details will be displayed here.",
+    "loading": "Loading repository...",
+    "loadingPullRequests": "Loading pull requests...",
+    "errorLoadingPullRequests": "Error loading pull requests: {error}",
+    "noPullRequests": "No pull requests found for this repository.",
+    "pullRequestTimeline": "Pull Request Timeline"
+  },
+  "projects": {
+    "title": "Projects",
+    "subtitle": "Explore open source projects and their pull requests",
+    "search": {
+      "placeholder": "Search by project name or owner..."
+    },
+    "stats": {
+      "totalProjects": "Total Projects",
+      "totalPullRequests": "Total Pull Requests",
+      "uniqueContributors": "Unique Contributors"
+    },
+    "projects": {
+      "title": "Project Directory",
+      "pullRequests": "pull requests",
+      "viewRepository": "View Repository",
+      "recentPullRequests": "Recent Pull Requests",
+      "view": "View",
+      "noResults": "No projects found matching your search."
+    },
+    "loading": "Loading projects...",
+    "cta": {
+      "title": "Interested in contributing?",
+      "description": "Explore these projects and make your mark on open source development.",
+      "backToHome": "Back to Home",
+      "viewContributors": "View Contributors"
+    }
+  }
 }


### PR DESCRIPTION
Suggestion: What about having a Projects page, where you can explore the different Logos repositories, have some basic info about them and see a timeline of the PRs that were merged & closed.

<img width="1919" height="953" alt="image" src="https://github.com/user-attachments/assets/771b6814-938d-43b4-8d48-1d5ae60f3e46" />

<img width="1919" height="953" alt="image" src="https://github.com/user-attachments/assets/b11bb051-58d5-4258-b2dd-c18be49ac50b" />

