### PR TITLE
[Hotfix] Remove leaderboard link from navigation for cleaner UI

### DIFF
--- a/components/site-headaer.tsx
+++ b/components/site-headaer.tsx
@@ -60,14 +60,6 @@ const Header = () => {
                   {t('nav.issues')}
                 </Typography>
               </Link>
-              <Link href={ROUTES.leaderboard}>
-                <Typography
-                  variant="body1"
-                  className={`underline-offset-5 hover:underline ${currentPath === ROUTES.leaderboard ? 'underline' : ''}`}
-                >
-                  {t('nav.leaderboard')}
-                </Typography>
-              </Link>
             </nav>
           </div>
 


### PR DESCRIPTION
Remove the leaderboard section which includes mockdata for development purposes
- Preview: https://contribute-logos-co-git-update-header-acidinfo.vercel.app/en/