### PR TITLE
Integrate Umami tracking script and implement event tracking

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           strategy="afterInteractive"
           src="https://umami.bi.status.im/script.js"
           data-website-id="92fb3459-5270-4ce8-a81b-70bee39fbdfe"
-          data-domains="contribute.logos.co,contribute-logos-co-git-umami-analytics-acidinfo.vercel.app"
+          data-domains="contribute.logos.co"
         />
 
         {/* Schema.org JSON-LD */}

--- a/components/form/contact-form.tsx
+++ b/components/form/contact-form.tsx
@@ -7,14 +7,6 @@ import { useSubmitContribution } from '@/hooks/useSubmitContribution'
 import { useLocale } from 'next-intl'
 import { ROUTES } from '@/constants/routes'
 
-declare global {
-  interface Window {
-    umami: {
-      track: (event: string, data: Record<string, string>) => void
-    }
-  }
-}
-
 const RichTextEditor = dynamic(() => import('./rich-text-editor'), {
   ssr: false,
   loading: () => (

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,3 +37,11 @@ declare module '@tiptap/extension-placeholder' {
   const Placeholder: any
   export default Placeholder
 }
+
+declare global {
+  interface Window {
+    umami: {
+      track: (event: string, data: Record<string, string>) => void
+    }
+  }
+}


### PR DESCRIPTION
## Umami dashboard
https://umami.bi.status.im/websites/92fb3459-5270-4ce8-a81b-70bee39fbdfe

## Preview
https://contribute-logos-co-git-umami-analytics-acidinfo.vercel.app/en/proposals/

## Todo
Removing the `contribute-logos-co-git-umami-analytics-acidinfo.vercel.app` domain from the script after review

## Screenshot
<img width="1413" height="712" alt="Screenshot 2025-11-26 at 8 10 47 PM" src="https://github.com/user-attachments/assets/d5af5a11-c313-4da4-ab32-ad8e69838d61" />
