### PR TITLE
fix(resources): activists page differ in ko & eng locales

### DIFF
--- a/content/resources/fr/activists.mdx
+++ b/content/resources/fr/activists.mdx
@@ -1,52 +1,53 @@
 ---
-title: For Activists
-description: A guide to contributing to Logos as an activist.
+title: To contribute locally
+description: A guide to contributing to Logos within your local community.
 locale: fr
 ---
 
-Activists play a crucial role in Logos. You help translate decentralised technology into real-world impact, empower communities, identify threats to civil liberties, and create local strategies that advance autonomy and freedom.
+Everyday people working to improve lives at the local level play a crucial role in Logos. You help translate decentralised technology into real-world impact, empower communities, identify threats to civil liberties, and create local strategies that advance autonomy and freedom.
 
-If you're interested in contributing to Logos as an activist, you can submit a proposal [via the proposal form](/proposals).
+If you're interested in contributing to Logos at the local level, you can submit a proposal [via the proposal form](/proposals).
 
 <br />
 
-## Attend a Circle IRL or Start One
+# Attend a Circle IRL or start one
 
-- Join a Logos Circle in your city to connect with other organisers, technologists, artists, and researchers.
+Join a Logos Circle in your city to connect with other organisers, technologists, artists, and researchers.
 
-- If there isn’t one near you, you can apply to start a Circle and receive support with
-  - onboarding
-  - event structure
-  - communication materials
-  - support on local outreach.
+If there isn’t one near you, you can apply to start a Circle and receive support with:
+
+- Onboarding.
+- Event structure.
+- Communication materials.
+- Support with local outreach.
 
 [Find a Circle](https://luma.com/logosevents) in a city near you, or [schedule a call](https://cal.com/team/logos-onboarding/intro?overlayCalendar=true) to discuss starting a Circle.
 
 <br />
 
-## Contribute to Winnable Issues
+# Contribute to winnable issues
 
 Winnable issues are practical, achievable projects that directly improve people’s lives, and are developed through a Circle to ensure community ownership, local insight, and real-world impact.
 
-As an activist, you can contribute by:
+As a Circle contributor, you can contribute by:
 
-- Helping with research, organising, and executing the next steps
-- Coordinating volunteers
-- Connecting your issue with relevant groups, journalists, or organisations
+- Helping with research, organising, and executing new and ongoing initiatives.
+- Coordinating volunteers.
+- Connecting your issue with relevant groups, journalists, or organisations.
 - Documenting progress and sharing outcomes.
 
 [Find winnable issues](https://contribute.logos.co/en/issues/) to contribute to.
 
 <br />
 
-## Follow Logos Forum Threads
+# Follow Logos Forum threads
 
 The Logos Forum is where Circle stewards and contributors:
 
-- share detailed updates
-- document progress
-- propose new winnable issues
-- coordinate between cities
-- post research, case studies, and ideas.
+- Share detailed updates.
+- Document progress.
+- Propose new winnable issues.
+- Coordinate between cities.
+- Post research, case studies, and ideas.
 
 [Following the forum](https://forum.logos.co/) helps you understand what's happening across the network and where your input can make the greatest impact.

--- a/content/resources/ko/activists.mdx
+++ b/content/resources/ko/activists.mdx
@@ -1,52 +1,53 @@
 ---
-title: For Activists
-description: A guide to contributing to Logos as an activist.
+title: To contribute locally
+description: A guide to contributing to Logos within your local community.
 locale: ko
 ---
 
-Activists play a crucial role in Logos. You help translate decentralised technology into real-world impact, empower communities, identify threats to civil liberties, and create local strategies that advance autonomy and freedom.
+Everyday people working to improve lives at the local level play a crucial role in Logos. You help translate decentralised technology into real-world impact, empower communities, identify threats to civil liberties, and create local strategies that advance autonomy and freedom.
 
-If you're interested in contributing to Logos as an activist, you can submit a proposal [via the proposal form](/proposals).
+If you're interested in contributing to Logos at the local level, you can submit a proposal [via the proposal form](/proposals).
 
 <br />
 
-## Attend a Circle IRL or Start One
+# Attend a Circle IRL or start one
 
-- Join a Logos Circle in your city to connect with other organisers, technologists, artists, and researchers.
+Join a Logos Circle in your city to connect with other organisers, technologists, artists, and researchers.
 
-- If there isn’t one near you, you can apply to start a Circle and receive support with
-  - onboarding
-  - event structure
-  - communication materials
-  - support on local outreach.
+If there isn’t one near you, you can apply to start a Circle and receive support with:
+
+- Onboarding.
+- Event structure.
+- Communication materials.
+- Support with local outreach.
 
 [Find a Circle](https://luma.com/logosevents) in a city near you, or [schedule a call](https://cal.com/team/logos-onboarding/intro?overlayCalendar=true) to discuss starting a Circle.
 
 <br />
 
-## Contribute to Winnable Issues
+# Contribute to winnable issues
 
 Winnable issues are practical, achievable projects that directly improve people’s lives, and are developed through a Circle to ensure community ownership, local insight, and real-world impact.
 
-As an activist, you can contribute by:
+As a Circle contributor, you can contribute by:
 
-- Helping with research, organising, and executing the next steps
-- Coordinating volunteers
-- Connecting your issue with relevant groups, journalists, or organisations
+- Helping with research, organising, and executing new and ongoing initiatives.
+- Coordinating volunteers.
+- Connecting your issue with relevant groups, journalists, or organisations.
 - Documenting progress and sharing outcomes.
 
 [Find winnable issues](https://contribute.logos.co/en/issues/) to contribute to.
 
 <br />
 
-## Follow Logos Forum Threads
+# Follow Logos Forum threads
 
 The Logos Forum is where Circle stewards and contributors:
 
-- share detailed updates
-- document progress
-- propose new winnable issues
-- coordinate between cities
-- post research, case studies, and ideas.
+- Share detailed updates.
+- Document progress.
+- Propose new winnable issues.
+- Coordinate between cities.
+- Post research, case studies, and ideas.
 
 [Following the forum](https://forum.logos.co/) helps you understand what's happening across the network and where your input can make the greatest impact.


### PR DESCRIPTION
- Activists page https://dev-contribute.logos.co/en/resources/activists/ in Korean and French differs from the English version. Now it should be the same for the three locales.
  - https://contribute-logos-co-git-fix-resources-activists-9f8263-acidinfo.vercel.app/en/resources/activists/
  - https://contribute-logos-co-git-fix-resources-activists-9f8263-acidinfo.vercel.app/fr/resources/activists/
  - https://contribute-logos-co-git-fix-resources-activists-9f8263-acidinfo.vercel.app/ko/resources/activists/